### PR TITLE
Apply all arguments to transducer as function.

### DIFF
--- a/dist/ramda.js
+++ b/dist/ramda.js
@@ -7,23 +7,6 @@
 
     'use strict';
 
-    var XMap = function () {
-        function XMap(f, xf) {
-            this.xf = xf;
-            this.f = f;
-        }
-        XMap.prototype.init = function () {
-            return this.xf.init();
-        };
-        XMap.prototype.result = function (result) {
-            return this.xf.result(result);
-        };
-        XMap.prototype.step = function (result, input) {
-            return this.xf.step(result, this.f(input));
-        };
-        return XMap;
-    }();
-
     var __ = void 0;
 
     var _add = function _add(a, b) {
@@ -308,6 +291,26 @@
     };
 
     var _symTransformer = typeof Symbol !== 'undefined' ? Symbol('transformer') : '@@transformer';
+
+    var _xmap = function () {
+        function _xmap(f, xf) {
+            return new XMap(f, xf);
+        }
+        function XMap(f, xf) {
+            this.xf = xf;
+            this.f = f;
+        }
+        XMap.prototype.init = function () {
+            return this.xf.init();
+        };
+        XMap.prototype.result = function (result) {
+            return this.xf.result(result);
+        };
+        XMap.prototype.step = function (result, input) {
+            return this.xf.step(result, this.f(input));
+        };
+        return _xmap;
+    }();
 
     var always = function always(val) {
         return function () {
@@ -1532,12 +1535,12 @@
         }, [], fns);
     };
 
-    var _dispatchable = function _dispatchable(name, fn, X) {
+    var _dispatchable = function _dispatchable(name, fn, xf) {
         return function (a, b, c) {
             var length = arguments.length;
             var obj = arguments[length - 1];
             if (_isTransformer(obj)) {
-                return new X(arguments[0], obj);
+                return xf.apply(null, arguments);
             }
             var callBound = obj && !_isArray(obj) && typeof obj[name] === 'function';
             switch (arguments.length) {
@@ -1696,7 +1699,7 @@
         });
     });
 
-    var map = _curry2(_dispatchable('map', _map, XMap));
+    var map = _curry2(_dispatchable('map', _map, _xmap));
 
     var mixin = _curry2(function mixin(a, b) {
         return _extend(_extend({}, a), b);
@@ -1820,7 +1823,6 @@
         F: F,
         I: I,
         T: T,
-        XMap: XMap,
         __: __,
         add: add,
         all: all,

--- a/src/internal/_dispatchable.js
+++ b/src/internal/_dispatchable.js
@@ -1,13 +1,13 @@
 var _isArray = require('./_isArray');
 var _isTransformer = require('./_isTransformer');
 
-module.exports = function _dispatchable(name, fn, X) {
+module.exports = function _dispatchable(name, fn, xf) {
     return function(a, b, c) {
         var length = arguments.length;
         var obj = arguments[length - 1];
 
         if (_isTransformer(obj)) {
-            return new X(arguments[0], obj);
+            return xf.apply(null, arguments);
         }
         var callBound = obj && !_isArray(obj) && typeof obj[name] === 'function';
         switch (arguments.length) {

--- a/src/internal/_xmap.js
+++ b/src/internal/_xmap.js
@@ -1,4 +1,7 @@
 module.exports = (function() {
+    function _xmap(f, xf) {
+        return new XMap(f, xf);
+    }
 
     function XMap(f, xf) {
         this.xf = xf;
@@ -17,5 +20,5 @@ module.exports = (function() {
         return this.xf.step(result, this.f(input));
     };
 
-    return XMap;
-}());
+    return _xmap;
+})();

--- a/src/map.js
+++ b/src/map.js
@@ -1,7 +1,7 @@
-var XMap = require('./XMap');
 var _curry2 = require('./internal/_curry2');
 var _dispatchable = require('./internal/_dispatchable');
 var _map = require('./internal/_map');
+var _xmap = require('./internal/_xmap');
 
 /**
  * Returns a new list, constructed by applying the supplied function to every element of the
@@ -26,4 +26,4 @@ var _map = require('./internal/_map');
  *
  *      R.map(double, [1, 2, 3]); //=> [2, 4, 6]
  */
-module.exports = _curry2(_dispatchable('map', _map, XMap));
+module.exports = _curry2(_dispatchable('map', _map, _xmap));

--- a/test/map.js
+++ b/test/map.js
@@ -21,8 +21,6 @@ describe('map', function() {
             step: function(acc, x) { return acc.concat(x); },
             result: function(x) { return x; }
         };
-        var xd = R.map(add1, obj);
-        assert(xd instanceof R.XMap);
         assert.deepEqual(R.map(add1, obj), {
             f: add1,
             xf: obj


### PR DESCRIPTION
A small tweak to the implementation of the mapping transducer.  Moved XMap to internal/_xmap and export a function. Changed dispatcher to apply arguments to transducer function as some transducers may require more than one initial argument.
